### PR TITLE
Fix E_NOTICE errors when module is added when fields are already created

### DIFF
--- a/linked_field.module
+++ b/linked_field.module
@@ -177,8 +177,8 @@ function linked_field_entity_display_build_alter(&$build, $context) {
 
     foreach (Element::children($element) as $delta) {
       // Normalize the settings.
-      $linked = $settings['linked'];
-      $destination = $settings['destination'];
+      $linked = empty($settings['linked']) ? false : $settings['linked'];
+      $destination = empty($settings['destination']) ? false : $settings['destination'];
 
       // If the destination field isn't filled for this field, we shouldn't
       // do anything. Continue to the next field.


### PR DESCRIPTION
When this module is installed and Contents types / fields are already present a bunch of E_NOTICE appears (2 errors per existing field) because $settings['linked'] and $settings['destination'] don't exist
